### PR TITLE
Add histogram support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ ls ./target/athenz_metrics_prometheus-*.jar
     # for dev. env. ONLY, record Athenz domain data as label
     athenz.metrics.prometheus.label.request_domain_name.enable=false
     athenz.metrics.prometheus.label.principal_domain_name.enable=false
+    # enable histogram for aggregatable calculation of quantiles
+    athenz.metrics.prometheus.histogram.enable=true
+    athenz.metrics.prometheus.histogram.buckets=0.005,0.01,0.025,0.05,0.075,0.1,0.25,0.5,0.75,1.0,2.5,5.0,7.5,10.0
     ```
 1. verify setup: `curl localhost:8181/metrics`
 1. add job in your Prometheus server

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <groupId>com.yahoo.athenz</groupId>
   <artifactId>athenz_metrics_prometheus</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
   <name>athenz_metrics_prometheus</name>
   <description>Athenz Yahoo Server Metrics Interface implementation for Prometheus</description>
 

--- a/src/main/java/com/yahoo/athenz/common/metrics/impl/prometheus/PrometheusMetricFactory.java
+++ b/src/main/java/com/yahoo/athenz/common/metrics/impl/prometheus/PrometheusMetricFactory.java
@@ -16,6 +16,7 @@
 package com.yahoo.athenz.common.metrics.impl.prometheus;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.prometheus.client.Collector;
@@ -44,6 +45,8 @@ public class PrometheusMetricFactory implements MetricFactory {
     public static final String LABEL_HTTP_STATUS_NAME_ENABLE_PROP = "label.http_status_name.enable";
     public static final String LABEL_API_NAME_ENABLE_PROP = "label.api_name.enable";
 
+    public static final String HISTOGRAM_ENABLE_PROP = "histogram.enable";
+    public static final String HISTOGRAM_BUCKETS_PROP = "histogram.buckets";
 
     @Override
     public Metric create() {
@@ -91,6 +94,20 @@ public class PrometheusMetricFactory implements MetricFactory {
         boolean isLabelHttpMethodNameEnable = Boolean.valueOf(getProperty(LABEL_HTTP_METHOD_NAME_ENABLE_PROP, "false"));
         boolean isLabelHttpStatusNameEnable = Boolean.valueOf(getProperty(LABEL_HTTP_STATUS_NAME_ENABLE_PROP, "false"));
         boolean isLabelApiNameEnable = Boolean.valueOf(getProperty(LABEL_API_NAME_ENABLE_PROP, "false"));
+        boolean isHistogramEnable = Boolean.valueOf(getProperty(HISTOGRAM_ENABLE_PROP, "false"));
+        double[] histogramBuckets = null;
+
+        String histogramBucketsStr = getProperty(HISTOGRAM_BUCKETS_PROP, "");
+        if (!histogramBucketsStr.equals("")) {
+            try {
+                histogramBuckets = Arrays.stream(histogramBucketsStr.split(","))
+                        .mapToDouble(Double::parseDouble)
+                        .toArray();
+            } catch (NumberFormatException e) {
+                throw new RuntimeException("Invalid property format: " + SYSTEM_PROP_PREFIX + HISTOGRAM_BUCKETS_PROP);
+            }
+        }
+
         return new PrometheusMetric(
                 registry,
                 namesToCollectors,
@@ -100,8 +117,9 @@ public class PrometheusMetricFactory implements MetricFactory {
                 isLabelPrincipalDomainNameEnable,
                 isLabelHttpMethodNameEnable,
                 isLabelHttpStatusNameEnable,
-                isLabelApiNameEnable);
-
+                isLabelApiNameEnable,
+                isHistogramEnable,
+                histogramBuckets);
     }
 
     /**


### PR DESCRIPTION
## Summary
I added histogram for aggregatable calculation of quantiles.

## Usage
Add the following system properties.
The default value for buckets is the same as for simpleclient (`[0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0]`).
```
athenz.metrics.prometheus.histogram.enable=true
athenz.metrics.prometheus.histogram.buckets=0.01,0.05,0.1,0.25,0.5,0.75,1.0, 2.5
```